### PR TITLE
Fixed pause menu to main menu bug.

### DIFF
--- a/Content/UserInterface/PauseMenu_W.uasset
+++ b/Content/UserInterface/PauseMenu_W.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:33d939cffa4f926659047331b05bae719d35e153d3d77794c3e46b2f4dbeecb4
-size 65853
+oid sha256:7b183b460587c3a314b57ebec188a81c852c6b0055ece5bf0808612890c0618b
+size 76667


### PR DESCRIPTION
Bug: When pause menu was initiated and player clicked 'Return to menu' button, then clicked the play button from the main menu, player was unable to move or interact in any way.

Fix: Added logic to pause menu before changing to main menu map.